### PR TITLE
Updated README.md Docker info

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This is simple and doesn't require any dependencies or system modifications, jus
 $ docker run -it cznic/knot-resolver
 ```
 
-See the build page [hub.docker.com/u/cznic/knot-resolver](https://hub.docker.com/r/cznic/knot-resolver/) for more information and options.
+See the build page [hub.docker.com/r/cznic/knot-resolver](https://hub.docker.com/r/cznic/knot-resolver/) for more information and options.
 
 ### Running
 

--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ See the [Building project][depends] documentation page for more information.
 This is simple and doesn't require any dependencies or system modifications, just run:
 
 ```
-$ docker run cznic/knot-resolver
+$ docker run -it cznic/knot-resolver
 ```
 
-See the build page [registry.hub.docker.com/u/cznic/knot-resolver](https://registry.hub.docker.com/u/cznic/knot-resolver) for more information and options.
+See the build page [hub.docker.com/u/cznic/knot-resolver](https://hub.docker.com/r/cznic/knot-resolver/) for more information and options.
 
 ### Running
 


### PR DESCRIPTION
Updated Docker run command, because without -it (interactive) switch, kresd would freeze upon startup on [system] interactive mode. That may as well be a defect, but adding -it helps in all cases.
Also updated the Docker hub URL to the correct address (you'd get redirected automatically, but still).