### PR TITLE
Tip for running kresd in containers.

### DIFF
--- a/daemon/README.rst
+++ b/daemon/README.rst
@@ -244,6 +244,16 @@ Another example would show how it is possible to bind to all interfaces, using i
 		net.listen(addr_list)
 	end
 
+.. tip:: Some users observed a considerable, close to 100%, performance gain in Docker containers when they bound the daemon to a single interface:ip address pair. One may expand the aforementioned example with browsing available addresses as:
+
+	.. code-block:: lua
+
+		addrpref = env.EXPECTED_ADDR_PREFIX
+		for k, v in pairs(addr_list["addr"]) do
+			if string.sub(v,1,string.len(addrpref)) == addrpref then
+				net.listen(v)
+		...
+
 You can also use third-party packages (available for example through LuaRocks_) as on this example
 to download cache from parent, to avoid cold-cache start.
 


### PR DESCRIPTION
Based on [issue 28](https://github.com/CZ-NIC/knot-resolver/issues/28), we were able to boost kresd performance running in a Docker container on DockerCloud by nearly 100% by binding to a single interface:ipaddress. It might be handy for other users to know.