### PR TITLE
mdoules/http: fixed mixed up argument order error in websocket code

### DIFF
--- a/modules/http/http.lua
+++ b/modules/http/http.lua
@@ -161,7 +161,7 @@ local function route(endpoints)
 		local m = h:get(':method')
 		local path = h:get(':path')
 		-- Upgrade connection to WebSocket
-		local ws = http_websocket.new_from_stream(h, stream)
+		local ws = http_websocket.new_from_stream(stream, h)
 		if ws then
 			assert(ws:accept { protocols = {'json'} })
 			-- Continue streaming results to client


### PR DESCRIPTION
lua-http decided to swap arguments some time ago:
https://github.com/daurnimator/lua-http/commit/507396bb960b4f9d2b666ae7fd1ea441e9cccd2f