### PR TITLE
daemon: fixed memory leak and array bounds check fail

### DIFF
--- a/daemon/bindings.c
+++ b/daemon/bindings.c
@@ -302,10 +302,9 @@ static int net_interfaces(lua_State *L)
 		char *p = buf;
 		memset(buf, 0, sizeof(buf));
 		for (unsigned k = 0; k < sizeof(iface.phys_addr); ++k) {
-			sprintf(p, "%.2x:", iface.phys_addr[k] & 0xff);
+			sprintf(p, "%s%.2x", k > 0 ? ":" : "", iface.phys_addr[k] & 0xff);
 			p += 3;
 		}
-		*(p - 1) = '\0';
 		lua_pushstring(L, buf);
 		lua_setfield(L, -2, "mac");
 

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -408,6 +408,7 @@ static int run_worker(uv_loop_t *loop, struct engine *engine, fd_array_t *ipc_se
 	return kr_ok();
 }
 
+#ifdef HAS_SYSTEMD
 static void free_sd_socket_names(char **socket_names, int count)
 {
 	for (int i = 0; i < count; i++) {
@@ -415,6 +416,7 @@ static void free_sd_socket_names(char **socket_names, int count)
 	}
 	free(socket_names);
 }
+#endif
 
 int main(int argc, char **argv)
 {

--- a/modules/cookies/cookiemonster.c
+++ b/modules/cookies/cookiemonster.c
@@ -75,8 +75,6 @@ static int srvr_sockaddr_cc_check(const struct sockaddr *srvr_sa,
 		return -2;
 	}
 
-	const struct knot_cc_alg *cc_alg = NULL;
-
 	assert(clnt_sett->current.secr);
 
 	/* The address must correspond with the client cookie. */
@@ -87,7 +85,7 @@ static int srvr_sockaddr_cc_check(const struct sockaddr *srvr_sa,
 		.secret_len = clnt_sett->current.secr->size
 	};
 
-	cc_alg = kr_cc_alg_get(clnt_sett->current.alg_id);
+	const struct knot_cc_alg *cc_alg = kr_cc_alg_get(clnt_sett->current.alg_id);
 	if (!cc_alg) {
 		return -2;
 	}


### PR DESCRIPTION
Fixed memory leak when outbound query fails to check out for some reason, cleaned up some other minor issues.