### PR TITLE
lib: make map_contains recongize null value

### DIFF
--- a/lib/generic/map.c
+++ b/lib/generic/map.c
@@ -118,24 +118,7 @@ static cb_data_t *cbt_make_data(map_t *map, const uint8_t *str, size_t len, void
 	return x;
 }
 
-/*! Creates a new, empty critbit map */
-EXPORT map_t map_make(void)
-{
-	map_t map;
-	map.root = NULL;
-	map.malloc = &malloc_std;
-	map.free = &free_std;
-	map.baton = NULL;
-	return map;
-}
-
-/*! Returns non-zero if map contains str */
-EXPORT int map_contains(map_t *map, const char *str)
-{
-	return map_get(map, str) != NULL;
-}
-
-EXPORT void *map_get(map_t *map, const char *str)
+static int cbt_get(map_t *map, const char *str, void **value)
 {
 	const uint8_t *ubytes = (void *)str;
 	const size_t ulen = strlen(str);
@@ -143,7 +126,7 @@ EXPORT void *map_get(map_t *map, const char *str)
 	cb_data_t *x = NULL;
 
 	if (p == NULL) {
-		return NULL;
+		return 0;
 	}
 
 	while (ref_is_internal(p)) {
@@ -161,10 +144,37 @@ EXPORT void *map_get(map_t *map, const char *str)
 
 	x = (cb_data_t *)p;
 	if (strcmp(str, (const char *)x->key) == 0) {
-		return x->value;
+		if (value != NULL) {
+			*value = x->value;
+		}
+		return 1;
 	}
 
-	return NULL;
+	return 0;
+}
+
+/*! Creates a new, empty critbit map */
+EXPORT map_t map_make(void)
+{
+	map_t map;
+	map.root = NULL;
+	map.malloc = &malloc_std;
+	map.free = &free_std;
+	map.baton = NULL;
+	return map;
+}
+
+/*! Returns non-zero if map contains str */
+EXPORT int map_contains(map_t *map, const char *str)
+{
+	return cbt_get(map, str, NULL);
+}
+
+EXPORT void *map_get(map_t *map, const char *str)
+{
+	void *v = NULL;
+	cbt_get(map, str, &v);
+	return v;
 }
 
 /*! Inserts str into map, returns 0 on success */

--- a/tests/test_map.c
+++ b/tests/test_map.c
@@ -90,6 +90,17 @@ static void test_delete(void **state)
 	assert_int_equal(map_del(tree, "most likely not in tree"), 1);
 }
 
+/* Test null value existence */
+static void test_null_value(void **state)
+{
+	map_t *tree = *state;
+	char *key = "foo";
+
+	assert_int_equal(map_set(tree, key, (void *)0), 0);
+	assert_true(map_contains(tree, key));
+	assert_int_equal(map_del(tree, key), 0);
+}
+
 static void test_init(void **state)
 {
 	static map_t tree;
@@ -112,6 +123,7 @@ int main(int argc, char **argv)
 	        unit_test(test_insert),
 		unit_test(test_get),
 		unit_test(test_delete),
+		unit_test(test_null_value),
 	        group_test_teardown(test_deinit)
 	};
 


### PR DESCRIPTION
Without changing the interface, map_contains is able to tell whether
the item exist in map or not.