### PR TITLE
add section name for kresd remote control

### DIFF
--- a/daemon/README.rst
+++ b/daemon/README.rst
@@ -1228,6 +1228,9 @@ You can add, start and stop processes during runtime based on the load.
 
 .. note:: On recent Linux supporting ``SO_REUSEPORT`` (since 3.9, backported to RHEL 2.6.32) it is also able to bind to the same endpoint and distribute the load between the forked processes. If your OS doesn't support it, use only one daemon process.
 
+Remote control
+==============
+
 Notice the absence of an interactive CLI. You can attach to the the consoles for each process, they are in ``rundir/tty/PID``.
 
 .. code-block:: bash


### PR DESCRIPTION
I had trouble finding how to remotely control the `kresd` process, in [this discussion][1]. Reading other parts of the documentation, we would be led to believe that just starting another process would be sufficient, but it's not actually the case.

By adding an extra header, I am hoping users will be clearly drawn towards that part of the documentation when looking for that feature.

[1]: https://forum.turris.cz/t/how-to-flush-dns-cache-or-force-a-refresh/6615/7