### PR TITLE
Correct help function output in docker config.

### DIFF
--- a/etc/config.docker
+++ b/etc/config.docker
@@ -29,7 +29,7 @@ function print_help()
 	   .. 'Docker will map ports 53, 853, and 8053 to some other numbers, see\n'
 	   .. '$ docker ps\n'
 	   .. '(column PORTS)\n'
-	   .. '80   -> DNS protocol over UDP and TCP\n'
+	   .. '53   -> DNS protocol over UDP and TCP\n'
 	   .. '853  -> DNS-over-TLS protocol\n'
 	   .. '8053 -> web interface\n'
 	   .. '\n'


### PR DESCRIPTION
Previously the help function output in the docker config listed port 80
as the port on which the server would listen for DNS over UDP and TCP.
However that was inconsistent with the first output line where it was
indicated to be port 53. This has now been corrected.