### PR TITLE
lib/cache: handle posix_fallocate returning EOPNOTSUPP (Linux/musl)

### DIFF
--- a/lib/cache/cdb_lmdb.c
+++ b/lib/cache/cdb_lmdb.c
@@ -381,9 +381,10 @@ static int cdb_open_env(struct lmdb_env *env, const char *path, const size_t map
 	} else {
 		ret = 0;
 	}
-	if (ret == EINVAL) {
+	if (ret == EINVAL || ret == EOPNOTSUPP) {
 		/* POSIX says this can happen when the feature isn't supported by the FS.
-		 * We haven't seen this happen on Linux+glibc but it was reported on FreeBSD.*/
+		 * We haven't seen this happen on Linux+glibc but it was reported on
+		 * Linux+musl and FreeBSD. */
 		kr_log_info(CACHE, "space pre-allocation failed and ignored; "
 				"your (file)system probably doesn't support it.\n");
 	} else if (ret != 0) {


### PR DESCRIPTION
https://man7.org/linux/man-pages/man3/posix_fallocate.3.html#ERRORS:
> EOPNOTSUPP
> The filesystem containing the file referred to by fd does not support
> this operation.  This error code can be returned by C libraries that
> don't perform the emulation shown in NOTES, such as **musl libc**.

I've encountered this problem on Alpine Linux running inside an LXC
container on Ubuntu with data on ZFS.