### PR TITLE
modules/dns64: add recomendation to also disable DNS64 via IPv4

### DIFF
--- a/modules/dns64/README.rst
+++ b/modules/dns64/README.rst
@@ -52,8 +52,11 @@ you can set ``DNS64_DISABLE`` flag via the :ref:`view module <mod-view>`.
 .. code-block:: lua
 
     modules = { 'dns64', 'view' }
-    -- Disable dns64 for everyone, but re-enable it for two particular subnets.
+    -- disable dns64 for all IPv4 source addresses
+    view:addr('0.0.0.0/0', policy.all(policy.FLAGS('DNS64_DISABLE')))
+    -- disable dns64 for all IPv6 source addresses
     view:addr('::/0', policy.all(policy.FLAGS('DNS64_DISABLE')))
+    -- re-enable dns64 for two IPv6 subnets
     view:addr('2001:db8:11::/48', policy.all(policy.FLAGS(nil, 'DNS64_DISABLE')))
     view:addr('2001:db8:93::/48', policy.all(policy.FLAGS(nil, 'DNS64_DISABLE')))
 


### PR DESCRIPTION
It's resonable to assume that people would also want to disable DNS64 for IPv4 source addresses if they only enable it for some IPv6 sources.