### PR TITLE
Update Arch Linux package URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Knot Resolver is also available from the following distributions' repositories.
   [Debian testing](https://packages.debian.org/testing/knot-resolver),
   [Debian unstable](https://packages.debian.org/sid/knot-resolver)
 * [Ubuntu](https://packages.ubuntu.com/jammy/knot-resolver)
-* [Arch Linux](https://archlinux.org/packages/community/x86_64/knot-resolver/)
+* [Arch Linux](https://archlinux.org/packages/extra/x86_64/knot-resolver/)
 * [Alpine Linux](https://pkgs.alpinelinux.org/packages?name=knot-resolver)
 
 ### Building from sources


### PR DESCRIPTION
The old URL returns 404 now.