### PR TITLE
lib/rules: add rpz-passthru support + fix ZLA overwrite bug

### DIFF
--- a/lib/rules/api.c
+++ b/lib/rules/api.c
@@ -493,6 +493,8 @@ int rule_local_data_answer(struct kr_query *qry, knot_pkt_t *pkt)
 			case KR_RULE_SUB_DNAME_FLAT:
 				ret = answer_zla_dname(ztype, qry, pkt, zla_lf, ttl, &val);
 				break;
+			case KR_RULE_SUB_PASSTHRU:
+				return RET_CONT_CACHE; // skip all local rules, fall through to recursion
 			default:
 				return kr_error(EILSEQ);
 			}
@@ -783,7 +785,7 @@ static int answer_zla_dname(val_zla_type_t type, struct kr_query *qry, knot_pkt_
 {
 	if (kr_fails_assert(type == KR_RULE_SUB_DNAME || type == KR_RULE_SUB_DNAME_FLAT))
 		return kr_error(EINVAL);
-	
+
 	const knot_dname_t *dname_target = val->data;
 	// Theoretically this check could overread the val->len, but that's OK,
 	// as the policy DB contents wouldn't be directly written by a malicious party.
@@ -953,6 +955,8 @@ int rule_local_subtree(const knot_dname_t *apex, enum kr_rule_sub_t type,
 	case KR_RULE_SUB_NODATA:
 	case KR_RULE_SUB_REDIRECT:
 		break;
+	case KR_RULE_SUB_PASSTHRU:
+ 		break;
 	default:
 		kr_assert(false);
 		return kr_error(EINVAL);

--- a/lib/rules/api.c
+++ b/lib/rules/api.c
@@ -634,6 +634,7 @@ int local_data_ins(knot_db_val_t key, const knot_rrset_t *rrs, const knot_rdatas
 	rdataset_dematerialize(sig_rds, data);
 
 	knot_db_val_t val = { .data = buf, .len = val_len };
+	ruledb_op(remove, &key, 1); // ignore error — key may not exist yet
 	int ret = ruledb_op(write, &key, &val, 1); // TODO: overwriting on ==tags?
 	// ENOSPC seems to be the only expectable error.
 	kr_assert(ret == 0 || ret == kr_error(ENOSPC));

--- a/lib/rules/api.h
+++ b/lib/rules/api.h
@@ -207,6 +207,8 @@ enum kr_rule_sub_t {
 	KR_RULE_SUB_DNAME,
 	/// Like _SUB_DNAME but the CNAMEs do not get prefixed.
 	KR_RULE_SUB_DNAME_FLAT,
+	/// Passthru: skip local rules for this subtree, recurse normally (RPZ rpz-passthru).
+	KR_RULE_SUB_PASSTHRU,
 };
 /** Insert a simple sub-tree rule.
  *

--- a/lib/rules/zonefile.c
+++ b/lib/rules/zonefile.c
@@ -84,7 +84,16 @@ static void cname_scan2rule(zs_scanner_t *s)
 	for (knot_dname_t *dn = s->r_data; *dn != '\0'; dn += 1 + *dn)
 		last_label = (const char *)dn + 1;
 	if (last_label && strncmp(last_label, "rpz-", 4) == 0) {
-		kr_log_warning(RULES, "skipping unsupported CNAME target .%s\n", last_label);
+		if (strcmp(last_label, "rpz-passthru") == 0) {
+			knot_dname_t *actual_owner = s->r_owner;
+			if (knot_dname_is_wildcard(actual_owner))
+				actual_owner += 2;
+			int ret = kr_rule_local_subtree(actual_owner, KR_RULE_SUB_PASSTHRU,
+							s->r_ttl, c->tags, c->opts);
+			if (ret) kr_log_warning(RULES, "rpz-passthru insertion failure: %d\n", ret);
+		} else {
+			kr_log_warning(RULES, "skipping unsupported CNAME target .%s\n", last_label);
+		}
 		return;
 	}
 	int ret = 0;


### PR DESCRIPTION
## Summary

Two related fixes for RPZ handling in the LMDB rules engine: the first is a standalone correctness bug, the second was the original motivation.

## Commits

**1. fix rule_local_subtree() silently discarding overwrites**

`ruledb_op(write)` uses `MDB_NOOVERWRITE`, so calling
`rule_local_subtree()` for a name that already has a ZLA entry silently
fails and keeps the old value. In release builds `kr_assert()` is a
no-op so this goes completely unnoticed.

Fixed by doing remove-then-write, mirroring the existing pattern in
`kr_rule_tag_add()` which already has an explicit comment about this.

**2. add RPZ rpz-passthru support**

`CNAME .rpz-passthru.` records are currently skipped with:
  [rules] skipping unsupported CNAME target .rpz-passthru

This was noted on the mailing list (Dec 2025): https://lists.nic.cz/hyperkitty/list/knot-resolver-users@lists.nic.cz/thread/6HL6T6NTKUPM3AWAOIH4TR77FYNFDMKU/

Adds `KR_RULE_SUB_PASSTHRU` as a new ZLA action type. When matched, `RET_CONT_CACHE` is returned immediately, falling through to recursive resolution and bypassing any remaining local rules.

Wildcard passthru records are handled by stripping the wildcard label before inserting the ZLA entry, consistent with how `CNAME .` records are processed.

## Context

We run a large blocklist (~2.7M RPZ entries) and needed per-domain whitelist overrides without rebuilding the whole zone. Tested on Knot Resolver 6.2.0, Arch Linux.

Load order note: whitelist RPZ should be listed **last** in config so PASSTHRU entries overwrite DENY entries from earlier files.