### PR TITLE
this fixes the issue where single kresd doesnt provide metrics on htt…

### DIFF
--- a/modules/http/prometheus.lua
+++ b/modules/http/prometheus.lua
@@ -15,8 +15,8 @@ local function merge(t, results, prefix)
 	for _, result in pairs(results) do
 		if type(result) == 'table' then
 			for k, v in pairs(result) do
-				if type(result) == 'table' then
-					merge(t, result, prefix..k..'.')
+				if type(v) == 'table' then
+					merge(t, {v}, prefix..k..'.')
 				else
 					local val = t[prefix..k]
 					t[prefix..k] = (val or 0) + v


### PR DESCRIPTION
this one should be quite straightforward but it took me an hour to find it.
i recently started upgrading my quite unique 5.7.6 setup to 6.3 and i'm running instances with the old kresd@.service, and i noticed that after configuring the http interface only two metrics were emmited.
this fixed the issue in my environment